### PR TITLE
ui refresh issue on object config and default, min, max values.

### DIFF
--- a/src/modules/my/buildContents/buildMeta.js
+++ b/src/modules/my/buildContents/buildMeta.js
@@ -122,7 +122,7 @@ export const buildMeta = (contents) => {
               propAttributes += ` datasource="${p.datasource}"`;
             }
             if (
-              p.default !== undefined &&
+              p.default &&
               !(
                 t.value === 'lightning__FlowScreen' &&
                 p.flowInput ^ p.flowOutput &&
@@ -136,14 +136,14 @@ export const buildMeta = (contents) => {
             }
             if (
               p.type === 'Integer' &&
-              p.min !== undefined &&
+              (p.min || p.min === 0) &&
               t.value !== 'lightning__FlowScreen'
             ) {
               propAttributes += ` min="${p.min}"`;
             }
             if (
               p.type === 'Integer' &&
-              p.max &&
+              (p.max || p.max === 0) &&
               t.value !== 'lightning__FlowScreen'
             ) {
               propAttributes += ` max="${p.max}"`;

--- a/src/modules/my/form/form.js
+++ b/src/modules/my/form/form.js
@@ -148,6 +148,8 @@ export default class Form extends LightningElement {
       (oId) => oId !== targetId
     );
     this.inputs.objects = this.inputs.objects.filter((o) => o.id !== targetId);
+    // update content when the object is deleted from config
+    this.updateContent();
   };
 
   onChangePropertyRow = (e) => {

--- a/src/modules/my/propertyDefinition/propertyDefinition.js
+++ b/src/modules/my/propertyDefinition/propertyDefinition.js
@@ -194,6 +194,12 @@ export default class PropertyDefinition extends LightningElement {
   onChangeSelect = (e) => {
     const key = e.target.attributes.name.value;
     this.property[key] = e.target.value;
+    // reset default, min, and max values on type change
+    if (key === 'type') {
+      this.property.min = '';
+      this.property.max = '';
+      this.property.default = '';
+    }
     this.updateProperty();
   };
 


### PR DESCRIPTION
Hello @ninoish & @albarivas,

You guys have done really great job building this project. I really appreciate that, thank you very much. 

Found some issues in the lwc builder UI.  So creating a PR for that. The details for the issues are as follows.
1. **buildMeta.js** line 125 - changed the condition so that the default attribute for the property is applied only when it is blank.
2. **buildMeta.js** line 139 & 146 - The min and max properties get applied even if the values are blank, so added conditions for that.
3. **form.js** - the object does not get removed if the delete button is clicked so, calling the `updateContent` function.
4. **propertyDefinition.js** - default, min, max values need to reset when the type of property gets changed, to avoid invalid datatype mismatch.

Please suggest if any changes are required. Thank you!