### PR TITLE
Support email and analytics targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-Salesforce Winter'23 v56.0 support.
-Salesforce Summer'22 v55.0 support.
+## [0.1.25] - 2022-10-26
+
+- Add Salesforce Winter'23 v56.0 version.
+- Add Salesforce Summer'22 v55.0 version.
+- Add lightningStatic\_\_Email support
+- Add analytics\_\_Dashboard
+- Add Responsive property attribute for lightningCommunity\_\_Default
+- Fix bug property bug on target uncheck
+- Fix wrong base class names for snapins targets
+- Fix preview not updated after property removal
+- Change property name after @api from break line to a whitespace.
 
 ## [0.1.22] - 2021-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 Salesforce Winter'23 v56.0 support.
 Salesforce Summer'22 v55.0 support.
+
 ## [0.1.22] - 2021-08-21
 
 Salesforce Summer'21 v52.0 support.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ LWC Builder is a tool to build, preview and configure Lightning Web Component (L
 Configure your component settings with clicks, then press "Create" button to create component files.
 
 ## Installation
+
 Now available on VSCode Marketplace
 https://marketplace.visualstudio.com/items?itemName=ninoish.lwc-builder
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lwc-builder-ui",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lwc-builder-ui",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lwc-builder-ui",
       "version": "0.1.24",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lwc-builder-ui",
   "description": "This package is a UI part of LWC Builder that enables you to configure Lightning Web Component (LWC) Bundle on VSCode",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "author": "@ninoish",
   "bugs": "https://github.com/developerforce/lwc-builder-ui/issues",
   "main": "dist/",

--- a/src/modules/my/buildContents/__tests__/buildJs.test.js
+++ b/src/modules/my/buildContents/__tests__/buildJs.test.js
@@ -25,7 +25,12 @@ const buildTargets = (option) => {
     { name: 'SnapinChatMessage', value: 'lightningSnapin__ChatMessage' },
     { name: 'SnapinMinimized', value: 'lightningSnapin__Minimized' },
     { name: 'SnapinPreChat', value: 'lightningSnapin__PreChat' },
-    { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' }
+    { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' },
+    {
+      name: 'Account Engagement (Pardot) Email',
+      value: 'lightningStatic__Email'
+    },
+    { name: 'CRM Analytics dashboard', value: 'analytics__Dashboard' }
   ];
   const targets = {};
   targetsArr.forEach((t) => {
@@ -77,12 +82,12 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
     )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
     expectedJs += `}`;
 
     expect(js).toBe(expectedJs);
@@ -106,20 +111,20 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
     )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
-    expectedJs += `\t@api\n\tdates;\n`;
-    expectedJs += `\t@api\n\temails;\n`;
-    expectedJs += `\t@api\n\tlocation;\n`;
-    expectedJs += `\t@api\n\tmessageBody;\n`;
-    expectedJs += `\t@api\n\tmode;\n`;
-    expectedJs += `\t@api\n\tpeople;\n`;
-    expectedJs += `\t@api\n\tsource;\n`;
-    expectedJs += `\t@api\n\tsubject;\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
+    expectedJs += `\t@api dates;\n`;
+    expectedJs += `\t@api emails;\n`;
+    expectedJs += `\t@api location;\n`;
+    expectedJs += `\t@api messageBody;\n`;
+    expectedJs += `\t@api mode;\n`;
+    expectedJs += `\t@api people;\n`;
+    expectedJs += `\t@api source;\n`;
+    expectedJs += `\t@api subject;\n`;
     expectedJs += `}`;
 
     expect(js).toBe(expectedJs);
@@ -143,13 +148,13 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `import BaseChatMessage from 'lightningsnapin/baseChatMessage';\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
-    )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
+    )} extends BaseChatMessage {\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
     expectedJs += `}`;
 
     expect(js).toBe(expectedJs);
@@ -173,13 +178,13 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `import { assignHandler, maximize } from 'lightningsnapin/minimized';\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
     )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
     expectedJs += `}`;
 
     expect(js).toBe(expectedJs);
@@ -203,13 +208,13 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `import BasePrechat from 'lightningsnapin/basePrechat';\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
-    )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
+    )} extends BasePrechat {\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
     expectedJs += `}`;
     expect(js).toBe(expectedJs);
   });
@@ -232,13 +237,72 @@ describe('my-build-js', () => {
     const js = buildJs(contents);
 
     // THEN
-    let expectedJs = `import { LightningElement , api } from "lwc";\n`;
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
     expectedJs += `import BaseChatHeader from 'lightningsnapin/baseChatHeader';\n`;
     expectedJs += `export default class ${pascalCase(
       contents.componentName
+    )} extends BaseChatHeader {\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
+    expectedJs += `}`;
+
+    expect(js).toBe(expectedJs);
+  });
+
+  it('returns correct js when lightningStatic__Email enabled', () => {
+    // GIVEN
+    const contents = {
+      properties: [{ name: 'myProp1' }, { name: 'myProp2' }],
+      targets: buildTargets({
+        lightningStatic__Email: { enabled: true }
+      }),
+      componentName: 'MyLWC'
+    };
+
+    // WHEN
+    const js = buildJs(contents);
+
+    // THEN
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
+    expectedJs += `export default class ${pascalCase(
+      contents.componentName
     )} extends LightningElement {\n`;
-    expectedJs += `\t@api\n\tmyProp1;\n`;
-    expectedJs += `\t@api\n\tmyProp2;\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
+    expectedJs += `}`;
+
+    expect(js).toBe(expectedJs);
+  });
+
+  it('returns correct js when analytics__Dashboard enabled', () => {
+    // GIVEN
+    const contents = {
+      properties: [{ name: 'myProp1' }, { name: 'myProp2' }],
+      targets: buildTargets({
+        analytics__Dashboard: { enabled: true, hasStep: true }
+      }),
+      componentName: 'MyLWC'
+    };
+
+    // WHEN
+    const js = buildJs(contents);
+
+    // THEN
+    let expectedJs = `import { LightningElement, api } from "lwc";\n`;
+    expectedJs += `export default class ${pascalCase(
+      contents.componentName
+    )} extends LightningElement {\n`;
+    expectedJs += `\t@api myProp1;\n`;
+    expectedJs += `\t@api myProp2;\n`;
+    expectedJs += `\t@api getState;\n`;
+    expectedJs += `\t@api setState;\n`;
+    expectedJs += `\t@api refresh;\n`;
+    expectedJs += `\t@api results;\n`;
+    expectedJs += `\t@api metadata;\n`;
+    expectedJs += `\t@api selectMode;\n`;
+    expectedJs += `\t@api selection;\n`;
+    expectedJs += `\t@api setSelection;\n`;
+    expectedJs += `\tstateChangedCallback(prevState, newState) {\n\t}\n`;
     expectedJs += `}`;
 
     expect(js).toBe(expectedJs);

--- a/src/modules/my/buildContents/__tests__/buildJs.test.js
+++ b/src/modules/my/buildContents/__tests__/buildJs.test.js
@@ -36,6 +36,7 @@ const buildTargets = (option) => {
       small: false,
       large: false,
       headlessAction: false,
+      hasStep: false,
       properties: [],
       objects: []
     };

--- a/src/modules/my/buildContents/buildCss.js
+++ b/src/modules/my/buildContents/buildCss.js
@@ -5,5 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export const buildCss = () => {
+  // TODO: apply responsive properties if set
+  // https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/get_started_responsive_properties.htm
   return `h1 {}`;
 };

--- a/src/modules/my/buildContents/buildJs.js
+++ b/src/modules/my/buildContents/buildJs.js
@@ -88,7 +88,7 @@ export const buildJs = (contents) => {
   js += `export default class ${pascal} extends ${classInheritance} {\n`;
   js += apis
     .map((p) => {
-      return p ? `\t@api\n\t${p};\n` : null;
+      return p ? `\t@api ${p};\n` : null;
     })
     .join('');
 

--- a/src/modules/my/buildContents/buildJs.js
+++ b/src/modules/my/buildContents/buildJs.js
@@ -25,24 +25,30 @@ export const buildJs = (contents) => {
 
   const recordRelatedProps = ['recordId', 'objectApiName'];
 
-  const apis = targets.lightning__Inbox.enabled
-    ? [
-        // merge @api properties for Inbox target.
-        ...propNames,
-        ...inboxProps.filter((ip) => {
-          return !propNames.includes(ip);
-        })
-      ]
-    : targets.lightning__RecordPage.enabled ||
+  const analyticsWithStepProps = [
+    'results',
+    'metadata',
+    'selectMode',
+    'selection',
+    'setSelection'
+  ];
+  const analyticsProps = ['getState', 'setState', 'refresh'];
+
+  const apis = [
+    ...new Set([
+      ...propNames,
+      ...(targets.lightning__Inbox.enabled ? inboxProps : []),
+      ...(targets.lightning__RecordPage.enabled ||
       targets.lightning__RecordAction.enabled
-    ? [
-        // merge @api properties for Record related target.
-        ...propNames,
-        ...recordRelatedProps.filter((rrp) => {
-          return !propNames.includes(rrp);
-        })
-      ]
-    : propNames;
+        ? recordRelatedProps
+        : []),
+      ...(targets.analytics__Dashboard.enabled ? analyticsProps : []),
+      ...(targets.analytics__Dashboard.enabled &&
+      targets.analytics__Dashboard.hasStep
+        ? analyticsWithStepProps
+        : [])
+    ])
+  ];
 
   const hasProperties = apis && apis.length > 0;
   const pascal = pascalCase(componentName);
@@ -92,6 +98,11 @@ export const buildJs = (contents) => {
     } else {
       js += `\tcloseModal() {\n\t\tthis.dispatchEvent(new CloseActionScreenEvent());\n\t}\n`;
     }
+  }
+
+  // analytics callback
+  if (targets.analytics__Dashboard.enabled) {
+    js += `\tstateChangedCallback(prevState, newState) {\n\t}\n`;
   }
 
   js += `}`;

--- a/src/modules/my/buildContents/buildJs.js
+++ b/src/modules/my/buildContents/buildJs.js
@@ -47,12 +47,15 @@ export const buildJs = (contents) => {
   const hasProperties = apis && apis.length > 0;
   const pascal = pascalCase(componentName);
   let js = '';
-  js += `import { LightningElement ${
+  js += `import { LightningElement${
     hasProperties ? ', api' : ''
   } } from "lwc";\n`;
+
+  let classInheritance = 'LightningElement';
   if (targets.lightningSnapin__ChatMessage.enabled) {
     // https://developer.salesforce.com/docs/component-library/bundle/lightningsnapin-base-chat-message/documentation
     js += `import BaseChatMessage from 'lightningsnapin/baseChatMessage';\n`;
+    classInheritance = 'BaseChatMessage';
   }
   if (targets.lightningSnapin__Minimized.enabled) {
     // https://developer.salesforce.com/docs/component-library/bundle/lightningsnapin-minimized/documentation
@@ -61,10 +64,12 @@ export const buildJs = (contents) => {
   if (targets.lightningSnapin__PreChat.enabled) {
     // https://developer.salesforce.com/docs/component-library/bundle/lightningsnapin-base-prechat/documentation
     js += `import BasePrechat from 'lightningsnapin/basePrechat';\n`;
+    classInheritance = 'BasePrechat';
   }
   if (targets.lightningSnapin__ChatHeader.enabled) {
     // https://developer.salesforce.com/docs/component-library/bundle/lightningsnapin-base-chat-header/documentation
     js += `import BaseChatHeader from 'lightningsnapin/baseChatHeader';\n`;
+    classInheritance = 'BaseChatHeader';
   }
 
   if (
@@ -74,7 +79,7 @@ export const buildJs = (contents) => {
     js += `import { CloseActionScreenEvent } from 'lightning/actions';\n`;
   }
 
-  js += `export default class ${pascal} extends LightningElement {\n`;
+  js += `export default class ${pascal} extends ${classInheritance} {\n`;
   js += apis
     .map((p) => {
       return p ? `\t@api\n\t${p};\n` : null;

--- a/src/modules/my/buildContents/buildMeta.js
+++ b/src/modules/my/buildContents/buildMeta.js
@@ -57,7 +57,7 @@ export const buildMeta = (contents) => {
     if (
       properties.length > 0 ||
       objects.length > 0 ||
-      enabledTargetArray.find((t) => t.small || t.large) ||
+      enabledTargetArray.find((t) => t.small || t.large || t.hasStep) ||
       enabledTargetArray.find((t) => t.value === 'lightning__RecordAction') ||
       (enabledTargetArray.length === 1 &&
         enabledTargetArray[0].value === 'lightning__FlowScreen' &&
@@ -86,7 +86,8 @@ export const buildMeta = (contents) => {
             enabledTargetArray.length === 1 &&
             enabledTargetArray[0].value === 'lightning__FlowScreen' &&
             configurationEditor
-          )
+          ) &&
+          !(t.value === 'analytics__Dashboard' && t.hasStep === true)
         ) {
           continue;
         }
@@ -189,6 +190,16 @@ export const buildMeta = (contents) => {
                 .join(',')}"`;
             }
 
+            // LWR Screen Responsive
+            // https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/get_started_responsive_properties.htm
+            if (
+              p.type === 'Integer' &&
+              t.value === 'lightningCommunity__Default' &&
+              p.screenResponsive
+            ) {
+              propAttributes += ` screenResponsive="true" exposedTo="css"`;
+            }
+
             return `\t\t\t<property${propAttributes} />`;
           })
           .join('\n');
@@ -230,6 +241,12 @@ export const buildMeta = (contents) => {
           }
           targetConfigs += `\t\t\t</supportedFormFactors>\n`;
         }
+
+        // CRM Analytics
+        if (t.value === 'analytics__Dashboard' && t.hasStep) {
+          targetConfigs += `\t\t\t<hasStep>true</hasStep>\n`;
+        }
+
         targetConfigs += `\t\t</targetConfig>\n`;
       }
     }

--- a/src/modules/my/form/__tests__/form.test.js
+++ b/src/modules/my/form/__tests__/form.test.js
@@ -59,6 +59,7 @@ EXPECTED_TARGETS.forEach((t) => {
     small: false,
     large: false,
     headlessAction: false,
+    hasStep: false,
     properties: [],
     objects: []
   };
@@ -262,7 +263,8 @@ describe('my-form', () => {
         enabled: true,
         small: false,
         large: false,
-        headlessAction: false
+        headlessAction: false,
+        hasStep: false
       }
     });
     target.dispatchEvent(event);
@@ -483,7 +485,8 @@ describe('my-form', () => {
         enabled: true,
         small: true,
         large: false,
-        headlessAction: false
+        headlessAction: false,
+        hasStep: false
       }
     });
     target.dispatchEvent(event);
@@ -590,7 +593,8 @@ describe('my-form', () => {
         enabled: true,
         small: false,
         large: false,
-        headlessAction: false
+        headlessAction: false,
+        hasStep: false
       }
     });
     target.dispatchEvent(event);

--- a/src/modules/my/form/__tests__/form.test.js
+++ b/src/modules/my/form/__tests__/form.test.js
@@ -28,7 +28,12 @@ const EXPECTED_TARGETS = [
   { name: 'SnapinChatMessage', value: 'lightningSnapin__ChatMessage' },
   { name: 'SnapinMinimized', value: 'lightningSnapin__Minimized' },
   { name: 'SnapinPreChat', value: 'lightningSnapin__PreChat' },
-  { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' }
+  { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' },
+  {
+    name: 'Account Engagement (Pardot) Email',
+    value: 'lightningStatic__Email'
+  },
+  { name: 'CRM Analytics dashboard', value: 'analytics__Dashboard' }
 ];
 
 const EXPECTED_INPUTS = {

--- a/src/modules/my/form/form.js
+++ b/src/modules/my/form/form.js
@@ -48,7 +48,12 @@ export default class Form extends LightningElement {
     { name: 'SnapinChatMessage', value: 'lightningSnapin__ChatMessage' },
     { name: 'SnapinMinimized', value: 'lightningSnapin__Minimized' },
     { name: 'SnapinPreChat', value: 'lightningSnapin__PreChat' },
-    { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' }
+    { name: 'SnapinChatHeader', value: 'lightningSnapin__ChatHeader' },
+    {
+      name: 'Account Engagement (Pardot) Email',
+      value: 'lightningStatic__Email'
+    },
+    { name: 'CRM Analytics dashboard', value: 'analytics__Dashboard' }
   ];
   pDefCount = 0;
   oDefCount = 0;
@@ -62,6 +67,7 @@ export default class Form extends LightningElement {
         small: false,
         large: false,
         headlessAction: false,
+        hasStep: false,
         properties: [],
         objects: []
       };
@@ -97,13 +103,14 @@ export default class Form extends LightningElement {
     if (!e.detail) {
       return;
     }
-    const { target, enabled, small, large, headlessAction } = e.detail;
+    const { target, enabled, small, large, headlessAction, hasStep } = e.detail;
 
     this.inputs.targets[target.value].enabled = enabled;
     if (enabled) {
       this.inputs.targets[target.value].small = small;
       this.inputs.targets[target.value].large = large;
       this.inputs.targets[target.value].headlessAction = headlessAction;
+      this.inputs.targets[target.value].hasStep = hasStep;
     }
     this.updateContent();
   }

--- a/src/modules/my/form/form.js
+++ b/src/modules/my/form/form.js
@@ -140,6 +140,7 @@ export default class Form extends LightningElement {
     this.inputs.properties = this.inputs.properties.filter(
       (p) => p.id !== targetId
     );
+    this.updateContent();
   };
 
   addObjectRow = () => {

--- a/src/modules/my/form/form.js
+++ b/src/modules/my/form/form.js
@@ -112,6 +112,16 @@ export default class Form extends LightningElement {
       this.inputs.targets[target.value].headlessAction = headlessAction;
       this.inputs.targets[target.value].hasStep = hasStep;
     }
+    // remove check of properties which targets are disabled.
+    if (!enabled) {
+      this.inputs.properties.forEach((p) => {
+        const si = p.selectedTargets.findIndex((st) => st === target.value);
+        if (si >= 0) {
+          p.selectedTargets.splice(si, 1);
+        }
+      });
+    }
+
     this.updateContent();
   }
 

--- a/src/modules/my/propertyDefinition/propertyDefinition.html
+++ b/src/modules/my/propertyDefinition/propertyDefinition.html
@@ -64,6 +64,15 @@
               <option value="Date">Date</option>
               <option value="DateTime">Datetime</option>
             </template>
+            <template if:true={isEmailOnly}>
+              <option value="Color">Color</option>
+              <option value="HorizontalAlignment">HorizontalAlignment</option>
+              <option value="VerticalAlignment">VerticalAlignment</option>
+            </template>
+            <template if:true={isAnalyticsOnly}>
+              <option value="Measure">Measure</option>
+              <option value="Dimension">Dimension</option>
+            </template>
           </select>
         </div>
       </div>
@@ -104,6 +113,29 @@
             class="slds-input"
             autocomplete="off"
           />
+        </div>
+      </div>
+    </template>
+
+    <template if:true={supportsScreenResponsive}>
+      <div class="slds-form-element slds-m-bottom_small">
+        <div class="slds-form-element__control">
+          <div class="slds-checkbox">
+            <input
+              type="checkbox"
+              name="screenResponsive"
+              id={screenResponsiveId}
+              value={property.screenResponsive}
+              checked={property.screenResponsive}
+              onchange={onChangeCheckbox}
+            />
+            <label class="slds-checkbox__label" for={screenResponsiveId}>
+              <span class="slds-checkbox_faux"></span>
+              <span class="slds-form-element__label"
+                >LWR Screen-Size Responsive</span
+              >
+            </label>
+          </div>
         </div>
       </div>
     </template>

--- a/src/modules/my/propertyDefinition/propertyDefinition.js
+++ b/src/modules/my/propertyDefinition/propertyDefinition.js
@@ -32,7 +32,8 @@ export default class PropertyDefinition extends LightningElement {
     flowInput: true,
     flowOutput: true,
     datasource: '',
-    cmsFilters: []
+    cmsFilters: [],
+    screenResponsive: false
   };
 
   filters = [
@@ -80,6 +81,24 @@ export default class PropertyDefinition extends LightningElement {
     return !!this.property.selectedTargets.find(
       (t) => t === 'lightning__FlowScreen'
     );
+  }
+
+  get isEmailOnly() {
+    return (
+      this.property.selectedTargets.length === 1 &&
+      this.property.selectedTargets[0] === 'lightningStatic__Email'
+    );
+  }
+
+  get isAnalyticsOnly() {
+    return (
+      this.property.selectedTargets.length === 1 &&
+      this.property.selectedTargets[0] === 'analytics__Dashboard'
+    );
+  }
+
+  get supportsScreenResponsive() {
+    return this.isCommunityDefaultOnly && this.isInteger;
   }
 
   get isApexClassType() {
@@ -153,6 +172,9 @@ export default class PropertyDefinition extends LightningElement {
   }
   get datasourceId() {
     return `datasource_${this.pid}`;
+  }
+  get screenResponsiveId() {
+    return `screenResponsive_${this.pid}`;
   }
 
   get isDefaultEnabled() {

--- a/src/modules/my/propertyDefinition/propertyDefinition.js
+++ b/src/modules/my/propertyDefinition/propertyDefinition.js
@@ -8,11 +8,9 @@ import { LightningElement, api, track } from 'lwc';
 import { sentenceCase, camelCase } from 'change-case';
 
 export default class PropertyDefinition extends LightningElement {
-  @api
-  pid = '';
+  @api pid = '';
 
-  @api
-  targets = [];
+  @api targets = [];
 
   @track
   property = {

--- a/src/modules/my/propertyDefinition/propertyDefinition.js
+++ b/src/modules/my/propertyDefinition/propertyDefinition.js
@@ -178,6 +178,7 @@ export default class PropertyDefinition extends LightningElement {
   }
 
   get isDefaultEnabled() {
+    // TODO: consider Dimension and Measure type
     return this.property.type !== 'apex' && this.property.type !== 'sobject';
   }
 

--- a/src/modules/my/targetDefinition/targetDefinition.html
+++ b/src/modules/my/targetDefinition/targetDefinition.html
@@ -102,5 +102,22 @@
         </span>
       </label>
     </template>
+
+    <template if:true={isHasStepSupported}>
+      <input
+        type="checkbox"
+        onchange={onChangeHasStepCheckbox}
+        id={hasStepFormId}
+        value={enableHasStep}
+        checked={enableHasStep}
+        disabled={disabledCheck}
+      />
+      <label class="slds-checkbox__label" for={hasStepFormId}>
+        <span class="slds-checkbox_faux"></span>
+        <span class="slds-form-element__label">
+          <span>Has Step</span>
+        </span>
+      </label>
+    </template>
   </div>
 </template>

--- a/src/modules/my/targetDefinition/targetDefinition.js
+++ b/src/modules/my/targetDefinition/targetDefinition.js
@@ -15,6 +15,7 @@ export default class TargetDefinition extends LightningElement {
     this.enableSmall = this.isSmallFormFactorSupported;
     this.enableLarge = this.isFormFactorSupported;
     this.enableHeadless = false;
+    this.enableHasStep = false;
     this.enabled = false;
   }
 
@@ -29,6 +30,11 @@ export default class TargetDefinition extends LightningElement {
 
   onChangeActionTypeCheckbox = (e) => {
     this.enableHeadless = e.target.checked;
+    this.onChange();
+  };
+
+  onChangeHasStepCheckbox = (e) => {
+    this.enableHasStep = e.target.checked;
     this.onChange();
   };
 
@@ -57,7 +63,8 @@ export default class TargetDefinition extends LightningElement {
           enabled: this.enabled,
           small: this.enableSmall,
           large: this.enableLarge,
-          headlessAction: this.enableHeadless
+          headlessAction: this.enableHeadless,
+          hasStep: this.enableHasStep
         }
       })
     );
@@ -85,5 +92,14 @@ export default class TargetDefinition extends LightningElement {
 
   get actionTypeFormId() {
     return `${this.target.value}-action-type`;
+  }
+
+  /* CRM Analytics dashboard */
+  get isHasStepSupported() {
+    return this.target.value === 'analytics__Dashboard';
+  }
+
+  get hasStepFormId() {
+    return `${this.target.value}-has-step`;
   }
 }


### PR DESCRIPTION
- Add Salesforce Winter'23 v56.0 version.
- Add Salesforce Summer'22 v55.0 version.
- Add lightningStatic\_\_Email support
- Add analytics\_\_Dashboard
- Add Responsive property attribute for lightningCommunity\_\_Default
- Fix bug property bug on target uncheck
- Fix wrong base class names for snapins targets
- Fix preview not updated after property removal
- Change property name after @api from break line to a whitespace.